### PR TITLE
Add basic Lark grammar and tests for string literals

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -1,0 +1,3 @@
+start: string
+string: STRING
+STRING: /"[^"]*"/ | /'[^']*'/

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    assert True

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -1,0 +1,12 @@
+import pytest
+from lark import Lark
+import os
+
+def test_string_literal_parsing():
+    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
+    with open(grammar_path) as grammar_file:
+        grammar = grammar_file.read()
+    parser = Lark(grammar, start='string')
+    test_string = '"hello"'
+    parse_tree = parser.parse(test_string)
+    assert str(parse_tree) == "Tree(string, [Token(STRING, '\"hello\"')])"

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -9,4 +9,4 @@ def test_string_literal_parsing():
     parser = Lark(grammar, start='string')
     test_string = '"hello"'
     parse_tree = parser.parse(test_string)
-    assert str(parse_tree) == "Tree(string, [Token(STRING, '\"hello\"')])"
+    assert str(parse_tree) == "Tree('string', [Token('STRING', '\"hello\"')])"


### PR DESCRIPTION
Implements a basic Lark grammar for string literals and introduces a test for parsing string literals using this grammar.

- **Grammar Definition**: Adds a new file `grammar.lark` that defines a basic Lark grammar capable of handling string literals, including both single and double-quoted strings.
- **Testing**: Removes the placeholder file `tests/test_dummy.py` and introduces `tests/test_string_literals.py`. This new test file contains a function `test_string_literal_parsing()` that utilizes the defined grammar to parse a simple string literal and asserts the correctness of the parsing result.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=44e197c7-6ac6-4b82-a6db-e60f86b1d98b).