### PR TITLE
Extend tests for string literals with single and double quotes

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -1,4 +1,4 @@
 start: string
 string: ESCAPED_STRING
 
-%import common.ESCAPED_STRING
+ESCAPED_STRING: /"(?:\\.|[^"\\])*"/ | /'(?:\\.|[^'\\])*'/

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -16,7 +16,13 @@ def test_string_literal_parsing():
         ('"hello"', "hello"),
         ('"hello\\nworld"', "hello\nworld"),
         ('"hello\\tworld"', "hello\tworld"),
-        ('"hello\\"world\\""', 'hello"world"')
+        ('"hello\\"world\\""', 'hello"world"'),
+        ("'hello'", "hello"),  # Single quotes test case
+        ("'hello\\'world\\''", "hello'world'"),  # Single quotes with escaped single quote
+        ('"hello\\\'world\\\'"', "hello\'world\'"),  # Double quotes with escaped single quote
+        ("'hello\\\"world\\\"'", 'hello"world"'),  # Single quotes with escaped double quote
+        ('"hello\'world\'"', "hello'world'"),  # Double quotes with single quote inside
+        ("'hello\"world\"'", 'hello"world"')  # Single quotes with double quote inside
     ]
     for test_string, expected in test_cases:
         result = parser.parse(test_string)


### PR DESCRIPTION
This pull request introduces enhancements and new test cases in `tests/test_string_literals.py` and updates the `grammar.lark` to support a wider range of string literal scenarios.

- **Enhances string literal parsing tests**: Adds new test cases to `tests/test_string_literals.py` for handling both single and double quotes as wrappers for inline string literals. This includes scenarios where strings contain escaped single quotes within single-quoted strings, escaped double quotes within single-quoted strings, and vice versa. This ensures comprehensive testing of string parsing capabilities.
- **Updates grammar for string literals**: Modifies `grammar.lark` to include an inline definition for `ESCAPED_STRING` that supports both single and double quotes. This change allows the parser to correctly interpret and handle strings wrapped in either type of quotation mark, enhancing the flexibility and robustness of string parsing.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=da181169-8353-4756-b024-81853f690039).