### PR TITLE
Update grammar for string definitions

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -1,4 +1,7 @@
 start: string
-string: ESCAPED_STRING
+string: ESCAPED_STRING | SINGLE_QUOTED_STRING
 
-ESCAPED_STRING: /"(?:\\.|[^"\\])*"/ | /'(?:\\.|[^'\\])*'/
+SINGLE_QUOTED_STRING: "'" _STRING_ESC_INNER "'"
+
+%import common.ESCAPED_STRING
+%import common._STRING_ESC_INNER


### PR DESCRIPTION
Updates the grammar in `grammar.lark` to support both double-quoted and single-quoted string definitions, aligning with the task requirements.

- **Grammar Modification**: Introduces a new rule `SINGLE_QUOTED_STRING` to match single-quoted strings, utilizing `_STRING_ESC_INNER` for the inner string content.
- **Rule Update**: Modifies the `start` rule to accept either `ESCAPED_STRING` or `SINGLE_QUOTED_STRING`, allowing for more flexible string parsing.
- **Import Statements**: Adds import statements for `common.ESCAPED_STRING` and `common._STRING_ESC_INNER` from Lark's common definitions, ensuring the grammar can utilize these predefined patterns.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=e2e16aa4-dd67-4df2-9945-96c74e672e73).