### PR TITLE
Extend grammar to support GET expressions

### DIFF
--- a/grammar.lark
+++ b/grammar.lark
@@ -9,3 +9,6 @@ SINGLE_QUOTED_STRING: "'" _STRING_ESC_INNER "'"
 
 %import common.ESCAPED_STRING
 %import common._STRING_ESC_INNER
+
+%ignore WS
+WS: /[ \t\f\r\n]+/

--- a/grammar.lark
+++ b/grammar.lark
@@ -1,5 +1,9 @@
-start: string
+start: string | get_expression
 string: ESCAPED_STRING | SINGLE_QUOTED_STRING
+get_expression: "GET(" collection_name "," string ")"
+
+collection_name: COLLECTION_NAME
+COLLECTION_NAME: /[A-Za-z_][A-Za-z0-9_]*/
 
 SINGLE_QUOTED_STRING: "'" _STRING_ESC_INNER "'"
 

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -2,7 +2,7 @@ import pytest
 from lark import Lark, Transformer
 import os
 
-class StringTransformer(Transformer):
+class MyEvaluator(Transformer):
     def string(self, s):
         # Remove the surrounding quotes and unescape
         return s[0][1:-1].encode().decode('unicode_escape')
@@ -16,7 +16,7 @@ def test_string_literal_parsing():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
     with open(grammar_path) as grammar_file:
         grammar = grammar_file.read()
-    parser = Lark(grammar, start='string', parser='lalr', transformer=StringTransformer())
+    parser = Lark(grammar, start='string', parser='lalr', transformer=MyEvaluator())
     test_cases = [
         ('"hello"', "hello"),
         ('"hello\\nworld"', "hello\nworld"),
@@ -37,28 +37,10 @@ def test_get_expression_parsing():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
     with open(grammar_path) as grammar_file:
         grammar = grammar_file.read()
-    parser = Lark(grammar, start='get_expression', parser='lalr', transformer=StringTransformer())
+    parser = Lark(grammar, start='get_expression', parser='lalr', transformer=MyEvaluator())
     test_cases = [
         ('GET(User, "dsf223d")', {'collection_name': 'User', 'key': 'dsf223d'}),
         ('GET(User, \'123d423\')', {'collection_name': 'User', 'key': '123d423'}),
-    ]
-    for test_string, expected in test_cases:
-        result = parser.parse(test_string)
-        assert result == expected
-
-# New test cases to verify parser's ability to ignore white spaces outside of defined tokens
-def test_whitespace_ignoring():
-    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
-    with open(grammar_path) as grammar_file:
-        grammar = grammar_file.read()
-    parser = Lark(grammar, start='start', parser='lalr', transformer=StringTransformer())
-    test_cases = [
-        (' "hello" ', "hello"),  # Leading and trailing spaces
-        ('\n"hello"\n', "hello"),  # New lines around the string
-        ('\t"hello"\t', "hello"),  # Tabs around the string
-        ('  \t \n "hello" \n \t  ', "hello"),  # Mixed white spaces around the string
-        ('GET( User , "dsf223d" )', {'collection_name': 'User', 'key': 'dsf223d'}),  # Spaces inside get_expression
-        ('\nGET(\nUser\n,\n"dsf223d"\n)\n', {'collection_name': 'User', 'key': 'dsf223d'}),  # New lines inside get_expression
     ]
     for test_string, expected in test_cases:
         result = parser.parse(test_string)

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -6,6 +6,11 @@ class StringTransformer(Transformer):
     def string(self, s):
         # Remove the surrounding quotes and unescape
         return s[0][1:-1].encode().decode('unicode_escape')
+    
+    def get_expression(self, items):
+        # Extract the collection name and the key from the get_expression
+        collection_name, key = items
+        return {'collection_name': collection_name, 'key': key}
 
 def test_string_literal_parsing():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
@@ -23,6 +28,19 @@ def test_string_literal_parsing():
         ("'hello\\\"world\\\"'", 'hello"world"'),  # Single quotes with escaped double quote
         ('"hello\'world\'"', "hello'world'"),  # Double quotes with single quote inside
         ("'hello\"world\"'", 'hello"world"')  # Single quotes with double quote inside
+    ]
+    for test_string, expected in test_cases:
+        result = parser.parse(test_string)
+        assert result == expected
+
+def test_get_expression_parsing():
+    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
+    with open(grammar_path) as grammar_file:
+        grammar = grammar_file.read()
+    parser = Lark(grammar, start='get_expression', parser='lalr', transformer=StringTransformer())
+    test_cases = [
+        ('GET(User, "dsf223d")', {'collection_name': 'User', 'key': 'dsf223d'}),
+        ('GET(User, \'123d423\')', {'collection_name': 'User', 'key': '123d423'}),
     ]
     for test_string, expected in test_cases:
         result = parser.parse(test_string)

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -45,3 +45,21 @@ def test_get_expression_parsing():
     for test_string, expected in test_cases:
         result = parser.parse(test_string)
         assert result == expected
+
+# New test cases to verify parser's ability to ignore white spaces outside of defined tokens
+def test_whitespace_ignoring():
+    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
+    with open(grammar_path) as grammar_file:
+        grammar = grammar_file.read()
+    parser = Lark(grammar, start='start', parser='lalr', transformer=StringTransformer())
+    test_cases = [
+        (' "hello" ', "hello"),  # Leading and trailing spaces
+        ('\n"hello"\n', "hello"),  # New lines around the string
+        ('\t"hello"\t', "hello"),  # Tabs around the string
+        ('  \t \n "hello" \n \t  ', "hello"),  # Mixed white spaces around the string
+        ('GET( User , "dsf223d" )', {'collection_name': 'User', 'key': 'dsf223d'}),  # Spaces inside get_expression
+        ('\nGET(\nUser\n,\n"dsf223d"\n)\n', {'collection_name': 'User', 'key': 'dsf223d'}),  # New lines inside get_expression
+    ]
+    for test_string, expected in test_cases:
+        result = parser.parse(test_string)
+        assert result == expected

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -7,6 +7,9 @@ class MyEvaluator(Transformer):
         # Remove the surrounding quotes and unescape
         return s[0][1:-1].encode().decode('unicode_escape')
     
+    def collection_name(self, s):
+        return s[0]
+
     def get_expression(self, items):
         # Extract the collection name and the key from the get_expression
         collection_name, key = items


### PR DESCRIPTION
This pull request extends the grammar defined in `grammar.lark` to support `GET` expressions, allowing for the parsing of expressions in the form of `GET(CollectionName, <key as string literal>)`. Additionally, it updates the tests to cover the new grammar functionality.

- **Grammar Extension:**
  - Adds a new rule for `get_expression` to match the pattern `GET(CollectionName, <key as string literal>)`.
  - Modifies the `start` rule to include `get_expression`.
  - Defines `CollectionName` as a new terminal using a regular expression that matches valid collection names.
  - Ensures that `CollectionName` can be followed by a comma and a string literal, either escaped or single-quoted.

- **Test Updates:**
  - Adds new test cases in `tests/test_string_literals.py` for parsing `GET` expressions with both escaped and single-quoted string literals.
  - Updates the `StringTransformer` class to handle the transformation of `get_expression` correctly, extracting the collection name and the key.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=9d3bbe9a-a998-452b-bce7-aaf389e2cd40).