### PR TITLE
Add Pypika test for encoding string literals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Andrei & Copilot"]
 [tool.poetry.dependencies]
 python = "^3.11"
 lark = "^0.11.2"
+pypika = "^0.48.8"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tests/test_sql_encoding.py
+++ b/tests/test_sql_encoding.py
@@ -1,0 +1,17 @@
+import pytest
+from pypika import Query, Table, Field
+
+def test_pypika_encoding_string_literals():
+    # Define a table
+    users = Table('users')
+    
+    # Construct a query with string literals containing both single and double quotes
+    query = Query.from_(users).select('*').where(
+        (Field('name') == "O'Reilly") & (Field('comment') == 'He said "Hello, World!"')
+    )
+    
+    # Expected SQL query
+    expected_query = "SELECT * FROM \"users\" WHERE \"name\"='O''Reilly' AND \"comment\"='He said \"Hello, World!\"'"
+    
+    # Assert the generated SQL query matches the expected output
+    assert str(query) == expected_query


### PR DESCRIPTION
Adds Pypika as a dependency and introduces a new unit test to demonstrate how Pypika handles encoding string literals with single and double quotes in SQL expressions.

- **Dependency Update**: Adds `pypika` to the project dependencies in `pyproject.toml` to enable SQL query construction and manipulation.
- **New Unit Test**: Introduces a new file `tests/test_sql_encoding.py` with a test function `test_pypika_encoding_string_literals`. This test demonstrates Pypika's capability to correctly encode string literals containing both single and double quotes in a SQL query, specifically within a SELECT statement with a WHERE clause.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=8834f6fc-c5b8-4190-99bb-c99ef4a27299).