### PR TITLE
Add test for newline handling in Pypika filters

### DIFF
--- a/tests/test_sql_encoding.py
+++ b/tests/test_sql_encoding.py
@@ -45,3 +45,18 @@ def test_pypika_encoding_with_arbitrary_unicode():
     
     # Assert the generated SQL query matches the expected output
     assert str(query) == expected_query
+
+def test_pypika_encoding_with_new_lines():
+    # Define a table
+    users = Table('users')
+    
+    # Construct a query with string literals containing new lines
+    query = Query.from_(users).select('*').where(
+        Field('bio') == 'Line1\nLine2\nLine3'
+    )
+    
+    # Expected SQL query
+    expected_query = "SELECT * FROM \"users\" WHERE \"bio\"='Line1\nLine2\nLine3'"
+    
+    # Assert the generated SQL query matches the expected output
+    assert str(query) == expected_query


### PR DESCRIPTION
Adds a new test function to `tests/test_sql_encoding.py` to verify Pypika's handling of new lines in SQL query filters.

- Introduces `test_pypika_encoding_with_new_lines`, a test function that constructs a SQL query with string literals containing new lines. This function aims to ensure that Pypika correctly encodes new lines within SQL queries.
- Asserts that the generated SQL query matches the expected output, validating the correct handling of new lines in filters by Pypika.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=5efa5d33-4aef-44c9-987c-43d266835ad2).