### PR TITLE
Integrate Earthly for build and test processes

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,4 @@
-name: Python application test
+name: Python application test with Earthly
 
 on:
   push:
@@ -9,18 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.11]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Setup Earthly
+      uses: earthly/actions/setup@v1
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install poetry
-        poetry install
-    - name: Run tests
-      run: poetry run pytest
+        earthly-version: 'latest'
+    - name: Run tests with Earthly
+      run: earthly +test

--- a/Earthfile
+++ b/Earthfile
@@ -1,0 +1,15 @@
+# Earthfile for building and testing the lark-escaping project
+FROM python:3.11
+
+# Install Poetry
+build:
+    RUN pip install poetry
+    COPY pyproject.toml poetry.lock ./
+    RUN poetry install
+    SAVE ARTIFACT . AS LOCAL ./
+
+# Run tests using pytest
+test:
+    FROM +build
+    COPY . .
+    RUN poetry run pytest

--- a/README.md
+++ b/README.md
@@ -20,3 +20,27 @@ For detailed versions of dependencies, refer to `pyproject.toml`. Key dependenci
 ## Playground for Copilot Workspace
 
 This repository also serves as a playground for experimenting with GitHub's Copilot Workspace, exploring its capabilities in code generation and assistance.
+
+## Using Earthly for Building and Testing
+
+This project supports building and testing with Earthly, a build automation tool that allows for repeatable and isolated builds. To use Earthly, ensure you have it installed on your system.
+
+### Building the Project
+
+To build the project with Earthly, run the following command:
+
+```shell
+earthly +build
+```
+
+This command will install all necessary dependencies and prepare the project for testing or deployment.
+
+### Running Tests
+
+To run tests using Earthly, execute the following command:
+
+```shell
+earthly +test
+```
+
+This will run all configured tests in an isolated environment, ensuring consistency across different machines and environments.


### PR DESCRIPTION
This pull request introduces Earthly to the lark-escaping project for build automation and testing, and updates the GitHub Actions workflow and documentation accordingly.

- **Adds an Earthfile**: A new `Earthfile` is introduced, specifying a Python 3.11 base image, and defining two targets: `build` for installing dependencies using Poetry, and `test` for running tests with pytest.
- **Updates GitHub Actions workflow**: The `.github/workflows/python-app.yml` file is modified to replace the previous test steps with a single step that sets up Earthly and runs the `+test` target defined in the `Earthfile`.
- **Enhances README documentation**: Instructions on how to use Earthly for building and testing the project are added to the `README.md`, including command examples for running the build and test targets.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=357a9929-41e6-4339-8160-48ae6919a2df).