### PR TITLE
Refactor grammar loading in test_string_literals

### DIFF
--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -2,6 +2,11 @@ import pytest
 from lark import Lark, Transformer
 import os
 
+def load_grammar():
+    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
+    with open(grammar_path) as grammar_file:
+        return grammar_file.read()
+
 class MyEvaluator(Transformer):
     def string(self, s):
         # Remove the surrounding quotes and unescape
@@ -16,9 +21,7 @@ class MyEvaluator(Transformer):
         return {'collection_name': collection_name, 'key': key}
 
 def test_string_literal_parsing():
-    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
-    with open(grammar_path) as grammar_file:
-        grammar = grammar_file.read()
+    grammar = load_grammar()
     parser = Lark(grammar, start='string', parser='lalr', transformer=MyEvaluator())
     test_cases = [
         ('"hello"', "hello"),
@@ -41,9 +44,7 @@ def test_string_literal_parsing():
         assert result == expected
 
 def test_get_expression_parsing():
-    grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
-    with open(grammar_path) as grammar_file:
-        grammar = grammar_file.read()
+    grammar = load_grammar()
     parser = Lark(grammar, start='get_expression', parser='lalr', transformer=MyEvaluator())
     test_cases = [
         ('GET(User, "dsf223d")', {'collection_name': 'User', 'key': 'dsf223d'}),


### PR DESCRIPTION
Refactors the grammar loading logic in `tests/test_string_literals.py` by introducing a new function and updating test functions to use it.

- Introduces a new function `load_grammar` that encapsulates the logic for reading the grammar from `grammar.lark`. This function is placed at the top of the file for easy access.
- Updates `test_string_literal_parsing` and `test_get_expression_parsing` functions to use the `load_grammar` function instead of duplicating the grammar loading logic. This change streamlines the process of obtaining the grammar for parsing tests.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=71df6a22-7c77-4ad7-96e6-0840479a682b).