### PR TITLE
Extract MyEvaluator into mydsl library

### DIFF
--- a/mydsl/__init__.py
+++ b/mydsl/__init__.py
@@ -1,0 +1,1 @@
+# This __init__.py file makes mydsl a Python package

--- a/mydsl/my_evaluator.py
+++ b/mydsl/my_evaluator.py
@@ -1,0 +1,14 @@
+from lark import Transformer
+
+class MyEvaluator(Transformer):
+    def string(self, s):
+        # Remove the surrounding quotes and unescape
+        return s[0][1:-1].encode().decode('unicode_escape')
+    
+    def collection_name(self, s):
+        return s[0]
+
+    def get_expression(self, items):
+        # Extract the collection name and the key from the get_expression
+        collection_name, key = items
+        return {'collection_name': collection_name, 'key': key}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = ["Andrei & Copilot"]
 python = "^3.11"
 lark = "^0.11.2"
 pypika = "^0.48.8"
+mydsl = {path = "./mydsl"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -1,24 +1,12 @@
 import pytest
-from lark import Lark, Transformer
+from lark import Lark
 import os
+from mydsl.my_evaluator import MyEvaluator
 
 def load_grammar():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
     with open(grammar_path) as grammar_file:
         return grammar_file.read()
-
-class MyEvaluator(Transformer):
-    def string(self, s):
-        # Remove the surrounding quotes and unescape
-        return s[0][1:-1].encode().decode('unicode_escape')
-    
-    def collection_name(self, s):
-        return s[0]
-
-    def get_expression(self, items):
-        # Extract the collection name and the key from the get_expression
-        collection_name, key = items
-        return {'collection_name': collection_name, 'key': key}
 
 def test_string_literal_parsing():
     grammar = load_grammar()


### PR DESCRIPTION
Extracts the `MyEvaluator` class into a new library module and updates dependencies accordingly.

- **Library Creation and Class Relocation**: Creates a new module `mydsl` with `my_evaluator.py` containing the `MyEvaluator` class, previously located in `tests/test_string_literals.py`. This change modularizes the codebase by separating the class definition into its own library.
- **Test Update**: Modifies `tests/test_string_literals.py` to import `MyEvaluator` from the newly created `mydsl` module, removing the class definition from the test file itself. This ensures that the tests are now dependent on the external `mydsl` library.
- **Dependency Management**: Updates `pyproject.toml` to include `mydsl` as a local dependency under `[tool.poetry.dependencies]`, facilitating the installation and management of this new library module as part of the project's dependencies.
- **Package Initialization**: Adds an `__init__.py` file to the `mydsl` directory, making it a Python package. This is a necessary step for it to be recognized as a module and imported in other parts of the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=fa6139b5-e399-48e4-b0bf-370c4206b1b0).