### PR TITLE
Move MyEvaluator into the mydsl package

### DIFF
--- a/mydsl/__init__.py
+++ b/mydsl/__init__.py
@@ -1,3 +1,4 @@
+from lark import Transformer
 
 class MyEvaluator(Transformer):
     """

--- a/mydsl/__init__.py
+++ b/mydsl/__init__.py
@@ -1,1 +1,17 @@
-# This __init__.py file makes mydsl a Python package
+
+class MyEvaluator(Transformer):
+    """
+    The MyEvaluator class is responsible for transforming the parsed tree into a more
+    useful format that can be easily manipulated and used within the application.
+    """
+    def string(self, s):
+        # Remove the surrounding quotes and unescape
+        return s[0][1:-1].encode().decode('unicode_escape')
+    
+    def collection_name(self, s):
+        return s[0]
+
+    def get_expression(self, items):
+        # Extract the collection name and the key from the get_expression
+        collection_name, key = items
+        return {'collection_name': collection_name, 'key': key}

--- a/mydsl/__init__.py
+++ b/mydsl/__init__.py
@@ -1,18 +1,1 @@
-from lark import Transformer
-
-class MyEvaluator(Transformer):
-    """
-    The MyEvaluator class is responsible for transforming the parsed tree into a more
-    useful format that can be easily manipulated and used within the application.
-    """
-    def string(self, s):
-        # Remove the surrounding quotes and unescape
-        return s[0][1:-1].encode().decode('unicode_escape')
-    
-    def collection_name(self, s):
-        return s[0]
-
-    def get_expression(self, items):
-        # Extract the collection name and the key from the get_expression
-        collection_name, key = items
-        return {'collection_name': collection_name, 'key': key}
+# This __init__.py file makes mydsl a Python package

--- a/mydsl/evaluator.py
+++ b/mydsl/evaluator.py
@@ -1,0 +1,18 @@
+from lark import Transformer
+
+class MyEvaluator(Transformer):
+    """
+    The MyEvaluator class is responsible for transforming the parsed tree into a more
+    useful format that can be easily manipulated and used within the application.
+    """
+    def string(self, s):
+        # Remove the surrounding quotes and unescape
+        return s[0][1:-1].encode().decode('unicode_escape')
+    
+    def collection_name(self, s):
+        return s[0]
+
+    def get_expression(self, items):
+        # Extract the collection name and the key from the get_expression
+        collection_name, key = items
+        return {'collection_name': collection_name, 'key': key}

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -1,7 +1,7 @@
 import pytest
-from lark import Lark, Transformer
+from lark import Lark
 import os
-from mydsl import MyEvaluator
+from mydsl.evaluator import MyEvaluator
 
 def load_grammar():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')

--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -1,24 +1,12 @@
 import pytest
 from lark import Lark, Transformer
 import os
+from mydsl import MyEvaluator
 
 def load_grammar():
     grammar_path = os.path.join(os.path.dirname(__file__), '..', 'grammar.lark')
     with open(grammar_path) as grammar_file:
         return grammar_file.read()
-
-class MyEvaluator(Transformer):
-    def string(self, s):
-        # Remove the surrounding quotes and unescape
-        return s[0][1:-1].encode().decode('unicode_escape')
-    
-    def collection_name(self, s):
-        return s[0]
-
-    def get_expression(self, items):
-        # Extract the collection name and the key from the get_expression
-        collection_name, key = items
-        return {'collection_name': collection_name, 'key': key}
 
 def test_string_literal_parsing():
     grammar = load_grammar()


### PR DESCRIPTION
Moves the `MyEvaluator` class from `tests/test_string_literals.py` to `mydsl/__init__.py` and updates import statements accordingly.

- **Class Relocation**: Removes the `MyEvaluator` class definition from `tests/test_string_literals.py` and adds it to `mydsl/__init__.py`. This change makes `MyEvaluator` part of the `mydsl` package.
- **Import Adjustment**: Updates the import statement in `tests/test_string_literals.py` to import `MyEvaluator` from the `mydsl` package, reflecting its new location.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=afb1b45e-63a3-4faa-8962-1299ed02796a).