### PR TITLE
Add test with native Japanese and Chinese characters

### DIFF
--- a/tests/test_string_literals.py
+++ b/tests/test_string_literals.py
@@ -26,7 +26,9 @@ def test_string_literal_parsing():
         ("'hello\\uABCDworld'", "hello\uABCDworld"),  # Single quotes with unicode character
         ('"\\nNew\\tLine\\u1234"', "\nNew\tLine\u1234"),  # New line, tab, and unicode character
         ("'\\nNew\\tLine\\uABCD'", "\nNew\tLine\uABCD"),  # New line, tab, and unicode character in single quotes
-        ('"extra letters ä, ö, ü."', "extra letters ä, ö, ü.")  # Test case for extra letters ä, ö, ü.
+        ('"extra letters ä, ö, ü."', "extra letters ä, ö, ü."),  # Test case for extra letters ä, ö, ü.
+        ('"こんにちは"', "こんにちは"),  # Double quotes with Japanese characters
+        ("'你好'", "你好")  # Single quotes with Chinese characters
     ]
     for test_string, expected in test_cases:
         result = parser.parse(test_string)


### PR DESCRIPTION
Add test cases for native Japanese and Chinese characters in `tests/test_string_literals.py`.

* Add test cases for double-quoted Japanese characters and single-quoted Chinese characters in the `test_string_literal_parsing` function.
* Ensure the parser correctly handles and transforms these characters.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/andreisavu/lark-escaping?shareId=1b4e4e22-172a-414f-8143-c8f87c1f4509).